### PR TITLE
feat : 포트폴리오 등록 조회 수정 기본 구조 잡는중

### DIFF
--- a/portfolio-server/build.gradle
+++ b/portfolio-server/build.gradle
@@ -21,8 +21,14 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    implementation 'org.projectlombok:lombok'
+    implementation 'org.mapstruct:mapstruct:1.4.2.Final'
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.4.2.Final'
+
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     runtimeOnly 'com.h2database:h2'
 }

--- a/portfolio-server/src/main/java/com/example/portfolioserver/JacksonConfig.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/JacksonConfig.java
@@ -1,0 +1,30 @@
+package com.example.portfolioserver;
+
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.format.DateTimeFormatter;
+import java.util.TimeZone;
+
+@Configuration
+public class JacksonConfig {
+
+    private static final String dateFormat = "yyyy-MM-dd";
+    private static final String datetimeFormat = "yyyy-MM-dd HH:mm:ss";
+
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jackson2ObjectMapperBuilderCustomizer(){
+        return jacksonObjectMapperBuilder -> {
+            jacksonObjectMapperBuilder.timeZone(TimeZone.getTimeZone("UTC"));
+            jacksonObjectMapperBuilder.serializers(new LocalDateSerializer(DateTimeFormatter.ofPattern(dateFormat)));
+            jacksonObjectMapperBuilder.serializers(new LocalDateTimeSerializer(DateTimeFormatter.ofPattern(datetimeFormat)));
+            jacksonObjectMapperBuilder.deserializers(new LocalDateDeserializer(DateTimeFormatter.ofPattern(dateFormat)));
+            jacksonObjectMapperBuilder.deserializers(new LocalDateTimeDeserializer(DateTimeFormatter.ofPattern(datetimeFormat)));
+        };
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/PortfolioServerApplication.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/PortfolioServerApplication.java
@@ -2,8 +2,12 @@ package com.example.portfolioserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
+@Import(JacksonConfig.class)
 public class PortfolioServerApplication {
 
     public static void main(String[] args) {

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/base/entity/BaseTimeEntity.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/base/entity/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.example.portfolioserver.domain.base.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+public class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdDate;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedDate;
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/basicinfo/dao/BasicInfoRepository.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/basicinfo/dao/BasicInfoRepository.java
@@ -1,0 +1,7 @@
+package com.example.portfolioserver.domain.basicinfo.dao;
+
+import com.example.portfolioserver.domain.basicinfo.entity.BasicInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BasicInfoRepository extends JpaRepository<BasicInfo, Long> {
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/basicinfo/dto/BasicInfoDto.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/basicinfo/dto/BasicInfoDto.java
@@ -1,0 +1,24 @@
+package com.example.portfolioserver.domain.basicinfo.dto;
+
+import com.example.portfolioserver.domain.basicinfo.entity.BasicInfo;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+public class BasicInfoDto {
+    private Long id;
+    @NotBlank(message = "Testsetest")
+    private String name;
+    private String email;
+    private String mobile;
+
+    public BasicInfo getEntity() {
+        return BasicInfo.builder()
+                .id(id)
+                .name(name)
+                .email(email)
+                .mobile(mobile)
+                .build();
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/basicinfo/dto/BasicInfoSearchDto.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/basicinfo/dto/BasicInfoSearchDto.java
@@ -1,0 +1,20 @@
+package com.example.portfolioserver.domain.basicinfo.dto;
+
+import com.example.portfolioserver.domain.basicinfo.entity.BasicInfo;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class BasicInfoSearchDto {
+
+    private String name;
+    private String email;
+    private String mobile;
+
+    public BasicInfoSearchDto(BasicInfo basicInfo) {
+        this.name = basicInfo.getName();
+        this.email = basicInfo.getEmail();
+        this.mobile = basicInfo.getMobile();
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/basicinfo/entity/BasicInfo.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/basicinfo/entity/BasicInfo.java
@@ -1,0 +1,38 @@
+package com.example.portfolioserver.domain.basicinfo.entity;
+
+import com.example.portfolioserver.domain.base.entity.BaseTimeEntity;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class BasicInfo extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy= GenerationType.IDENTITY)
+    private Long id;
+    private String name;
+    private String email;
+    private String mobile;
+
+    @Builder
+    public BasicInfo(Long id, String name, String email, String mobile) {
+        this.id = id;
+        this.name = name;
+        this.email = email;
+        this.mobile = mobile;
+    }
+
+    public void edit(String email, String mobile, String name) {
+        this.email = email;
+        this.mobile = mobile;
+        this.name = name;
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/career/dao/CareerRepository.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/career/dao/CareerRepository.java
@@ -1,0 +1,7 @@
+package com.example.portfolioserver.domain.career.dao;
+
+import com.example.portfolioserver.domain.career.entity.Career;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CareerRepository extends JpaRepository<Career, Long> {
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/career/dto/CareerDto.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/career/dto/CareerDto.java
@@ -1,0 +1,25 @@
+package com.example.portfolioserver.domain.career.dto;
+
+import com.example.portfolioserver.domain.career.entity.Career;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class CareerDto {
+    private Long id;
+    private String company;
+    private String duty;
+    private LocalDate periodFrom;
+    private LocalDate periodTo;
+
+    public Career getEntity() {
+        return Career.builder()
+                .id(id)
+                .company(company)
+                .duty(duty)
+                .periodFrom(periodFrom)
+                .periodTo(periodTo)
+                .build();
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/career/dto/CareerSearchDto.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/career/dto/CareerSearchDto.java
@@ -1,0 +1,25 @@
+package com.example.portfolioserver.domain.career.dto;
+
+import com.example.portfolioserver.domain.career.entity.Career;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class CareerSearchDto {
+    private Long id;
+    private String company;
+    private String duty;
+    private LocalDate periodFrom;
+    private LocalDate periodTo;
+
+    public CareerSearchDto(Career career) {
+        this.id = career.getId();
+        this.company = career.getCompany();
+        this.duty = career.getDuty();
+        this.periodFrom = career.getPeriodFrom();
+        this.periodTo = career.getPeriodTo();
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/career/entity/Career.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/career/entity/Career.java
@@ -1,0 +1,45 @@
+package com.example.portfolioserver.domain.career.entity;
+
+import com.example.portfolioserver.domain.base.entity.BaseTimeEntity;
+import com.example.portfolioserver.domain.portfolio.entity.Portfolio;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class Career extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "portfolio_id")
+    private Portfolio portfolio;
+
+    private String company;
+
+    private String duty;
+
+    private LocalDate periodFrom;
+
+    private LocalDate periodTo;
+
+    @Builder
+    public Career(Long id, String company, String duty, LocalDate periodFrom, LocalDate periodTo) {
+        this.id = id;
+        this.company = company;
+        this.duty = duty;
+        this.periodFrom = periodFrom;
+        this.periodTo = periodTo;
+    }
+
+    public void setPortfolio(Portfolio portfolio) {
+        this.portfolio = portfolio;
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/educationalhistory/dao/EducationalHistoryRepository.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/educationalhistory/dao/EducationalHistoryRepository.java
@@ -1,0 +1,8 @@
+package com.example.portfolioserver.domain.educationalhistory.dao;
+
+import com.example.portfolioserver.domain.educationalhistory.entity.EducationalHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface EducationalHistoryRepository extends JpaRepository<EducationalHistory, Long> { }

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/educationalhistory/dto/EducationalHistoryDto.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/educationalhistory/dto/EducationalHistoryDto.java
@@ -1,0 +1,27 @@
+package com.example.portfolioserver.domain.educationalhistory.dto;
+
+import com.example.portfolioserver.domain.educationalhistory.entity.EducationalHistory;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class EducationalHistoryDto {
+    private Long id;
+    private String school;
+    private String majorType;
+    private String majorDepartment;
+    private LocalDate periodFrom;
+    private LocalDate periodTo;
+
+    public EducationalHistory getEntity() {
+        return EducationalHistory.builder()
+                .id(id)
+                .school(school)
+                .majorType(majorType)
+                .majorDepartment(majorDepartment)
+                .periodFrom(periodFrom)
+                .periodTo(periodTo)
+                .build();
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/educationalhistory/dto/EducationalHistorySearchDto.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/educationalhistory/dto/EducationalHistorySearchDto.java
@@ -1,0 +1,28 @@
+package com.example.portfolioserver.domain.educationalhistory.dto;
+
+import com.example.portfolioserver.domain.educationalhistory.entity.EducationalHistory;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class EducationalHistorySearchDto {
+
+    private Long id;
+    private String school;
+    private String majorType;
+    private String majorDepartment;
+    private LocalDate periodFrom;
+    private LocalDate periodTo;
+
+    public EducationalHistorySearchDto(EducationalHistory educationalHistory) {
+        this.id = educationalHistory.getId();
+        this.school = educationalHistory.getSchool();
+        this.majorType = educationalHistory.getMajorType();
+        this.majorDepartment = educationalHistory.getMajorDepartment();
+        this.periodFrom = educationalHistory.getPeriodFrom();
+        this.periodTo = educationalHistory.getPeriodTo();
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/educationalhistory/entity/EducationalHistory.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/educationalhistory/entity/EducationalHistory.java
@@ -1,0 +1,48 @@
+package com.example.portfolioserver.domain.educationalhistory.entity;
+
+import com.example.portfolioserver.domain.base.entity.BaseTimeEntity;
+import com.example.portfolioserver.domain.portfolio.entity.Portfolio;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class EducationalHistory extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy=GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "portfolio_id")
+    private Portfolio portfolio;
+
+    private String school;
+
+    private String majorType;
+    private String majorDepartment;
+
+    private LocalDate periodFrom;
+    private LocalDate periodTo;
+
+    @Builder
+    public EducationalHistory(Long id, Portfolio portfolio, String school, String majorType, String majorDepartment, LocalDate periodFrom, LocalDate periodTo) {
+        this.id = id;
+        this.portfolio = portfolio;
+        this.school = school;
+        this.majorType = majorType;
+        this.majorDepartment = majorDepartment;
+        this.periodFrom = periodFrom;
+        this.periodTo = periodTo;
+    }
+
+    public void setPortfolio(Portfolio portfolio) {
+        this.portfolio = portfolio;
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/member/dao/MemberRepository.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/member/dao/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.example.portfolioserver.domain.member.dao;
+
+import com.example.portfolioserver.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/member/entity/Member.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/member/entity/Member.java
@@ -1,0 +1,18 @@
+package com.example.portfolioserver.domain.member.entity;
+
+import com.example.portfolioserver.domain.base.entity.BaseTimeEntity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class Member extends BaseTimeEntity {
+    @Id
+    @GeneratedValue
+    private Long id;
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/member/entity/member.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/member/entity/member.java
@@ -1,4 +1,0 @@
-package com.example.portfolioserver.domain.member.entity;
-
-public class member {
-}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/api/PortfolioApi.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/api/PortfolioApi.java
@@ -1,12 +1,8 @@
 package com.example.portfolioserver.domain.portfolio.api;
 
-import com.example.portfolioserver.domain.portfolio.application.PortfolioEditService;
-import com.example.portfolioserver.domain.portfolio.application.PortfolioRegisterService;
-import com.example.portfolioserver.domain.portfolio.application.PortfolioSearchService;
+import com.example.portfolioserver.domain.portfolio.application.*;
 import com.example.portfolioserver.domain.portfolio.dto.PortfolioDto;
-import com.example.portfolioserver.domain.portfolio.dto.PortfolioSearchDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/api/PortfolioApi.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/api/PortfolioApi.java
@@ -1,0 +1,40 @@
+package com.example.portfolioserver.domain.portfolio.api;
+
+import com.example.portfolioserver.domain.portfolio.application.PortfolioEditService;
+import com.example.portfolioserver.domain.portfolio.application.PortfolioRegisterService;
+import com.example.portfolioserver.domain.portfolio.application.PortfolioSearchService;
+import com.example.portfolioserver.domain.portfolio.dto.PortfolioDto;
+import com.example.portfolioserver.domain.portfolio.dto.PortfolioSearchDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+import java.net.URI;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/portfolio")
+public class PortfolioApi {
+
+    private final PortfolioRegisterService portfolioRegisterService;
+    private final PortfolioSearchService portfolioSearchService;
+    private final PortfolioEditService portfolioEditService;
+
+    @PostMapping("/{memberId}")
+    public ResponseEntity Register(@PathVariable Long memberId, @Valid @RequestBody PortfolioDto portfolioDto) {
+        Long id = portfolioRegisterService.Register(memberId, portfolioDto);
+        return ResponseEntity.created(URI.create("/portfolio/" + id)).build();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity Search(@PathVariable Long id) {
+        return ResponseEntity.ok(portfolioSearchService.Search(id));
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity Edit(@PathVariable Long id, @RequestBody PortfolioDto portfolioDto) {
+        return ResponseEntity.ok(portfolioEditService.Edit(id, portfolioDto));
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioEditService.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioEditService.java
@@ -1,0 +1,42 @@
+package com.example.portfolioserver.domain.portfolio.application;
+
+import com.example.portfolioserver.domain.basicinfo.entity.BasicInfo;
+import com.example.portfolioserver.domain.career.entity.Career;
+import com.example.portfolioserver.domain.educationalhistory.entity.EducationalHistory;
+import com.example.portfolioserver.domain.portfolio.dao.PortfolioRepository;
+import com.example.portfolioserver.domain.portfolio.dto.PortfolioDto;
+import com.example.portfolioserver.domain.portfolio.entity.Portfolio;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PortfolioEditService {
+
+    private final PortfolioRepository portfolioRepository;
+
+    public Long Edit(Long id, PortfolioDto portfolioDto) {
+        Portfolio portfolio = portfolioRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 포트폴리오가 없습니다."));
+        BasicInfo basicInfo = portfolioDto.getBasicInfoDto().getEntity();
+        List<EducationalHistory> educationalHistoryList = getEducationalHistoryList(portfolioDto);
+        List<Career> careerList = getCareerList(portfolioDto);
+        portfolio.editPortfolio(basicInfo, educationalHistoryList, careerList);
+        return portfolioRepository.save(portfolio).getId();
+    }
+
+    private List<EducationalHistory> getEducationalHistoryList(PortfolioDto portfolioEdit) {
+        return portfolioEdit.getEducationalHistoryDtos().stream()
+                .map(educationalHistoryEdit -> educationalHistoryEdit.getEntity())
+                .collect(Collectors.toList());
+    }
+
+    private List<Career> getCareerList(PortfolioDto portfolioDto) {
+        return portfolioDto.getCareerDtos().stream()
+                .map(careerDto -> careerDto.getEntity())
+                .collect(Collectors.toList());
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioEditService.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioEditService.java
@@ -1,42 +1,8 @@
 package com.example.portfolioserver.domain.portfolio.application;
 
-import com.example.portfolioserver.domain.basicinfo.entity.BasicInfo;
-import com.example.portfolioserver.domain.career.entity.Career;
-import com.example.portfolioserver.domain.educationalhistory.entity.EducationalHistory;
-import com.example.portfolioserver.domain.portfolio.dao.PortfolioRepository;
 import com.example.portfolioserver.domain.portfolio.dto.PortfolioDto;
-import com.example.portfolioserver.domain.portfolio.entity.Portfolio;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.stream.Collectors;
+public interface PortfolioEditService {
+    Long Edit(Long id, PortfolioDto portfolioDto);
 
-@Service
-@RequiredArgsConstructor
-public class PortfolioEditService {
-
-    private final PortfolioRepository portfolioRepository;
-
-    public Long Edit(Long id, PortfolioDto portfolioDto) {
-        Portfolio portfolio = portfolioRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("해당 포트폴리오가 없습니다."));
-        BasicInfo basicInfo = portfolioDto.getBasicInfoDto().getEntity();
-        List<EducationalHistory> educationalHistoryList = getEducationalHistoryList(portfolioDto);
-        List<Career> careerList = getCareerList(portfolioDto);
-        portfolio.editPortfolio(basicInfo, educationalHistoryList, careerList);
-        return portfolioRepository.save(portfolio).getId();
-    }
-
-    private List<EducationalHistory> getEducationalHistoryList(PortfolioDto portfolioEdit) {
-        return portfolioEdit.getEducationalHistoryDtos().stream()
-                .map(educationalHistoryEdit -> educationalHistoryEdit.getEntity())
-                .collect(Collectors.toList());
-    }
-
-    private List<Career> getCareerList(PortfolioDto portfolioDto) {
-        return portfolioDto.getCareerDtos().stream()
-                .map(careerDto -> careerDto.getEntity())
-                .collect(Collectors.toList());
-    }
 }

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioEditServiceImpl.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioEditServiceImpl.java
@@ -1,0 +1,42 @@
+package com.example.portfolioserver.domain.portfolio.application;
+
+import com.example.portfolioserver.domain.basicinfo.entity.BasicInfo;
+import com.example.portfolioserver.domain.career.entity.Career;
+import com.example.portfolioserver.domain.educationalhistory.entity.EducationalHistory;
+import com.example.portfolioserver.domain.portfolio.dao.PortfolioRepository;
+import com.example.portfolioserver.domain.portfolio.dto.PortfolioDto;
+import com.example.portfolioserver.domain.portfolio.entity.Portfolio;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PortfolioEditServiceImpl implements PortfolioEditService {
+
+    private final PortfolioRepository portfolioRepository;
+
+    public Long Edit(Long id, PortfolioDto portfolioDto) {
+        Portfolio portfolio = portfolioRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("해당 포트폴리오가 없습니다."));
+        BasicInfo basicInfo = portfolioDto.getBasicInfoDto().getEntity();
+        List<EducationalHistory> educationalHistoryList = getEducationalHistoryList(portfolioDto);
+        List<Career> careerList = getCareerList(portfolioDto);
+        portfolio.editPortfolio(basicInfo, educationalHistoryList, careerList);
+        return portfolioRepository.save(portfolio).getId();
+    }
+
+    private List<EducationalHistory> getEducationalHistoryList(PortfolioDto portfolioEdit) {
+        return portfolioEdit.getEducationalHistoryDtos().stream()
+                .map(educationalHistoryEdit -> educationalHistoryEdit.getEntity())
+                .collect(Collectors.toList());
+    }
+
+    private List<Career> getCareerList(PortfolioDto portfolioDto) {
+        return portfolioDto.getCareerDtos().stream()
+                .map(careerDto -> careerDto.getEntity())
+                .collect(Collectors.toList());
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioRegisterService.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioRegisterService.java
@@ -1,0 +1,49 @@
+package com.example.portfolioserver.domain.portfolio.application;
+
+import com.example.portfolioserver.domain.basicinfo.entity.BasicInfo;
+import com.example.portfolioserver.domain.career.entity.Career;
+import com.example.portfolioserver.domain.educationalhistory.entity.EducationalHistory;
+import com.example.portfolioserver.domain.member.dao.MemberRepository;
+import com.example.portfolioserver.domain.member.entity.Member;
+import com.example.portfolioserver.domain.portfolio.dao.PortfolioRepository;
+import com.example.portfolioserver.domain.portfolio.dto.PortfolioDto;
+import com.example.portfolioserver.domain.portfolio.entity.Portfolio;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PortfolioRegisterService {
+
+    private final MemberRepository memberRepository;
+    private final PortfolioRepository portfolioRepository;
+
+    public Long Register(Long memberId, PortfolioDto portfolioDto) {
+        Member member = getMember(memberId);
+        BasicInfo basicInfo = portfolioDto.getBasicInfoDto().getEntity();
+        List<EducationalHistory> educationalHistoryList = getEducationalHistoryList(portfolioDto);
+        List<Career> careerList = getCareerList(portfolioDto);
+        Portfolio portfolio = Portfolio.createPortfolio(member, basicInfo, educationalHistoryList, careerList);
+        return portfolioRepository.save(portfolio).getId();
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 아이디가 없습니다."));
+    }
+
+    private List<EducationalHistory> getEducationalHistoryList(PortfolioDto portfolioDto) {
+        return portfolioDto.getEducationalHistoryDtos().stream()
+                .map(educationalHistoryDto -> educationalHistoryDto.getEntity())
+                .collect(Collectors.toList());
+    }
+
+    private List<Career> getCareerList(PortfolioDto portfolioDto) {
+        return portfolioDto.getCareerDtos().stream()
+                .map(careerDto -> careerDto.getEntity())
+                .collect(Collectors.toList());
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioRegisterService.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioRegisterService.java
@@ -1,49 +1,7 @@
 package com.example.portfolioserver.domain.portfolio.application;
 
-import com.example.portfolioserver.domain.basicinfo.entity.BasicInfo;
-import com.example.portfolioserver.domain.career.entity.Career;
-import com.example.portfolioserver.domain.educationalhistory.entity.EducationalHistory;
-import com.example.portfolioserver.domain.member.dao.MemberRepository;
-import com.example.portfolioserver.domain.member.entity.Member;
-import com.example.portfolioserver.domain.portfolio.dao.PortfolioRepository;
 import com.example.portfolioserver.domain.portfolio.dto.PortfolioDto;
-import com.example.portfolioserver.domain.portfolio.entity.Portfolio;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-@Service
-@RequiredArgsConstructor
-public class PortfolioRegisterService {
-
-    private final MemberRepository memberRepository;
-    private final PortfolioRepository portfolioRepository;
-
-    public Long Register(Long memberId, PortfolioDto portfolioDto) {
-        Member member = getMember(memberId);
-        BasicInfo basicInfo = portfolioDto.getBasicInfoDto().getEntity();
-        List<EducationalHistory> educationalHistoryList = getEducationalHistoryList(portfolioDto);
-        List<Career> careerList = getCareerList(portfolioDto);
-        Portfolio portfolio = Portfolio.createPortfolio(member, basicInfo, educationalHistoryList, careerList);
-        return portfolioRepository.save(portfolio).getId();
-    }
-
-    private Member getMember(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("사용자 아이디가 없습니다."));
-    }
-
-    private List<EducationalHistory> getEducationalHistoryList(PortfolioDto portfolioDto) {
-        return portfolioDto.getEducationalHistoryDtos().stream()
-                .map(educationalHistoryDto -> educationalHistoryDto.getEntity())
-                .collect(Collectors.toList());
-    }
-
-    private List<Career> getCareerList(PortfolioDto portfolioDto) {
-        return portfolioDto.getCareerDtos().stream()
-                .map(careerDto -> careerDto.getEntity())
-                .collect(Collectors.toList());
-    }
+public interface PortfolioRegisterService {
+    Long Register(Long memberId, PortfolioDto portfolioDto);
 }

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioRegisterServiceImpl.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioRegisterServiceImpl.java
@@ -1,0 +1,49 @@
+package com.example.portfolioserver.domain.portfolio.application;
+
+import com.example.portfolioserver.domain.basicinfo.entity.BasicInfo;
+import com.example.portfolioserver.domain.career.entity.Career;
+import com.example.portfolioserver.domain.educationalhistory.entity.EducationalHistory;
+import com.example.portfolioserver.domain.member.dao.MemberRepository;
+import com.example.portfolioserver.domain.member.entity.Member;
+import com.example.portfolioserver.domain.portfolio.dao.PortfolioRepository;
+import com.example.portfolioserver.domain.portfolio.dto.PortfolioDto;
+import com.example.portfolioserver.domain.portfolio.entity.Portfolio;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class PortfolioRegisterServiceImpl implements PortfolioRegisterService {
+
+    private final MemberRepository memberRepository;
+    private final PortfolioRepository portfolioRepository;
+
+    public Long Register(Long memberId, PortfolioDto portfolioDto) {
+        Member member = getMember(memberId);
+        BasicInfo basicInfo = portfolioDto.getBasicInfoDto().getEntity();
+        List<EducationalHistory> educationalHistoryList = getEducationalHistoryList(portfolioDto);
+        List<Career> careerList = getCareerList(portfolioDto);
+        Portfolio portfolio = Portfolio.createPortfolio(member, basicInfo, educationalHistoryList, careerList);
+        return portfolioRepository.save(portfolio).getId();
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자 아이디가 없습니다."));
+    }
+
+    private List<EducationalHistory> getEducationalHistoryList(PortfolioDto portfolioDto) {
+        return portfolioDto.getEducationalHistoryDtos().stream()
+                .map(educationalHistoryDto -> educationalHistoryDto.getEntity())
+                .collect(Collectors.toList());
+    }
+
+    private List<Career> getCareerList(PortfolioDto portfolioDto) {
+        return portfolioDto.getCareerDtos().stream()
+                .map(careerDto -> careerDto.getEntity())
+                .collect(Collectors.toList());
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioSearchService.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioSearchService.java
@@ -1,20 +1,7 @@
 package com.example.portfolioserver.domain.portfolio.application;
 
-import com.example.portfolioserver.domain.portfolio.dao.PortfolioRepository;
 import com.example.portfolioserver.domain.portfolio.dto.PortfolioSearchDto;
-import com.example.portfolioserver.domain.portfolio.entity.Portfolio;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
-@Service
-@RequiredArgsConstructor
-public class PortfolioSearchService {
-
-    private final PortfolioRepository portfolioRepository;
-
-    public PortfolioSearchDto Search(Long id) {
-        Portfolio portfolio = portfolioRepository.Search(id).
-                orElseThrow(() -> new IllegalArgumentException(""));
-        return new PortfolioSearchDto(portfolio);
-    }
+public interface PortfolioSearchService {
+    PortfolioSearchDto Search(Long id);
 }

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioSearchService.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioSearchService.java
@@ -1,0 +1,20 @@
+package com.example.portfolioserver.domain.portfolio.application;
+
+import com.example.portfolioserver.domain.portfolio.dao.PortfolioRepository;
+import com.example.portfolioserver.domain.portfolio.dto.PortfolioSearchDto;
+import com.example.portfolioserver.domain.portfolio.entity.Portfolio;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PortfolioSearchService {
+
+    private final PortfolioRepository portfolioRepository;
+
+    public PortfolioSearchDto Search(Long id) {
+        Portfolio portfolio = portfolioRepository.Search(id).
+                orElseThrow(() -> new IllegalArgumentException(""));
+        return new PortfolioSearchDto(portfolio);
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioSearchServiceImpl.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/application/PortfolioSearchServiceImpl.java
@@ -1,0 +1,20 @@
+package com.example.portfolioserver.domain.portfolio.application;
+
+import com.example.portfolioserver.domain.portfolio.dao.PortfolioRepository;
+import com.example.portfolioserver.domain.portfolio.dto.PortfolioSearchDto;
+import com.example.portfolioserver.domain.portfolio.entity.Portfolio;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PortfolioSearchServiceImpl implements PortfolioSearchService {
+
+    private final PortfolioRepository portfolioRepository;
+
+    public PortfolioSearchDto Search(Long id) {
+        Portfolio portfolio = portfolioRepository.Search(id).
+                orElseThrow(() -> new IllegalArgumentException(""));
+        return new PortfolioSearchDto(portfolio);
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/dao/PortfolioRepository.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/dao/PortfolioRepository.java
@@ -1,0 +1,15 @@
+package com.example.portfolioserver.domain.portfolio.dao;
+
+import com.example.portfolioserver.domain.portfolio.entity.Portfolio;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
+    @Query(value = "select p from Portfolio p join fetch p.basicInfo b join fetch p.member m where p.id = :id")
+    Optional<Portfolio> Search(@Param(value = "id") Long id);
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/dto/PortfolioDto.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/dto/PortfolioDto.java
@@ -1,0 +1,20 @@
+package com.example.portfolioserver.domain.portfolio.dto;
+
+import com.example.portfolioserver.domain.basicinfo.dto.BasicInfoDto;
+import com.example.portfolioserver.domain.career.dto.CareerDto;
+import com.example.portfolioserver.domain.educationalhistory.dto.EducationalHistoryDto;
+import lombok.Getter;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.List;
+
+@Getter
+public class PortfolioDto {
+
+    @NotNull
+    @Valid
+    private BasicInfoDto basicInfoDto;
+    private List<EducationalHistoryDto> educationalHistoryDtos;
+    private List<CareerDto> careerDtos;
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/dto/PortfolioSearchDto.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/dto/PortfolioSearchDto.java
@@ -1,0 +1,33 @@
+package com.example.portfolioserver.domain.portfolio.dto;
+
+import com.example.portfolioserver.domain.basicinfo.dto.BasicInfoSearchDto;
+import com.example.portfolioserver.domain.career.dto.CareerSearchDto;
+import com.example.portfolioserver.domain.educationalhistory.dto.EducationalHistorySearchDto;
+import com.example.portfolioserver.domain.portfolio.entity.Portfolio;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+public class PortfolioSearchDto {
+
+    private LocalDateTime createdDate;
+    private LocalDateTime lastModifiedDate;
+    private BasicInfoSearchDto basicInfoSearchDto;
+    private List<EducationalHistorySearchDto> educationalHistorySearchDtos;
+    private List<CareerSearchDto> careerSearchDtos;
+
+    public PortfolioSearchDto(Portfolio portfolio) {
+        this.createdDate = portfolio.getCreatedDate();
+        this.lastModifiedDate = portfolio.getLastModifiedDate();
+        this.basicInfoSearchDto = new BasicInfoSearchDto(portfolio.getBasicInfo());
+        this.educationalHistorySearchDtos = portfolio.getEducationalHistoryList().stream()
+                .map(educationalHistory -> new EducationalHistorySearchDto(educationalHistory))
+                .collect(Collectors.toList());
+        this.careerSearchDtos = portfolio.getCareerList().stream()
+                .map(career -> new CareerSearchDto(career))
+                .collect(Collectors.toList());
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/entity/Portfolio.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/domain/portfolio/entity/Portfolio.java
@@ -1,0 +1,82 @@
+package com.example.portfolioserver.domain.portfolio.entity;
+
+import com.example.portfolioserver.domain.base.entity.BaseTimeEntity;
+import com.example.portfolioserver.domain.basicinfo.entity.BasicInfo;
+import com.example.portfolioserver.domain.career.entity.Career;
+import com.example.portfolioserver.domain.educationalhistory.entity.EducationalHistory;
+import com.example.portfolioserver.domain.member.entity.Member;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Portfolio extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy=GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "basic_info_id")
+    private BasicInfo basicInfo;
+
+    @OneToMany(mappedBy = "portfolio", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("periodFrom asc")
+    private List<EducationalHistory> educationalHistoryList = new ArrayList<>();
+
+    @OneToMany(mappedBy = "portfolio", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("periodFrom asc")
+    private List<Career> careerList = new ArrayList<>();
+
+    @Builder
+    public Portfolio(Member member, BasicInfo basicInfo) {
+        this.member = member;
+        this.basicInfo = basicInfo;
+    }
+
+    public void addEducationalHistory(EducationalHistory educationalHistory) {
+        educationalHistoryList.add(educationalHistory);
+        educationalHistory.setPortfolio(this);
+    }
+
+    public void addCareer(Career career) {
+        careerList.add(career);
+        career.setPortfolio(this);
+    }
+
+    public static Portfolio createPortfolio(Member member, BasicInfo basicInfo, List<EducationalHistory> educationalHistoryList, List<Career> careerList) {
+        Portfolio portfolio = Portfolio.builder()
+                .basicInfo(basicInfo)
+                .member(member)
+                .build();
+        for(EducationalHistory educationalHistory : educationalHistoryList) {
+            portfolio.addEducationalHistory(educationalHistory);
+        }
+        for(Career career : careerList) {
+            portfolio.addCareer(career);
+        }
+        return portfolio;
+    }
+
+    public void editPortfolio(BasicInfo basicInfo, List<EducationalHistory> educationalHistoryList, List<Career> careerList) {
+        this.basicInfo = basicInfo;
+        this.educationalHistoryList.clear();
+        for(EducationalHistory educationalHistory : educationalHistoryList) {
+            this.addEducationalHistory(educationalHistory);
+        }
+        this.careerList.clear();
+        for(Career career : careerList) {
+            this.addCareer(career);
+        }
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/global/ErrorInfo.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/global/ErrorInfo.java
@@ -1,0 +1,14 @@
+package com.example.portfolioserver.global;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorInfo {
+    private String field;
+    private String message;
+
+    public ErrorInfo(String field, String message) {
+        this.field = field;
+        this.message = message;
+    }
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/global/ErrorResponse.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/global/ErrorResponse.java
@@ -1,0 +1,20 @@
+package com.example.portfolioserver.global;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ErrorResponse {
+
+    public ErrorResponse(String message, List<ErrorInfo> details) {
+        super();
+        this.message = message;
+        this.details = details;
+    }
+
+    private String message;
+
+    //Specific errors in API request processing
+    private List<ErrorInfo> details;
+}

--- a/portfolio-server/src/main/java/com/example/portfolioserver/global/GlobalExceptionHandler.java
+++ b/portfolio-server/src/main/java/com/example/portfolioserver/global/GlobalExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.example.portfolioserver.global;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(value = {MethodArgumentNotValidException.class})
+    public ResponseEntity validationException(MethodArgumentNotValidException exception) {
+        List<ErrorInfo> details = new ArrayList<>();
+        for(ObjectError error : exception.getBindingResult().getAllErrors()) {
+            details.add(new ErrorInfo(error.getObjectName(), error.getDefaultMessage()));
+        }
+        ErrorResponse error = new ErrorResponse("Validation Failed", details);
+        return new ResponseEntity(error, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/portfolio-server/src/main/resources/application-test.yml
+++ b/portfolio-server/src/main/resources/application-test.yml
@@ -3,19 +3,24 @@ spring:
     console:
       enabled: true
       path: /h2-console
+  sql:
+    init:
+      mode: always
+      data-locations: classpath:data.sql
 
   datasource:
-    url: jdbc:h2:~/localdb/externship-h2-db
+    url: jdbc:h2:tcp://localhost/~/portfolio-server-h2-db
     username: sa
     password:
     driver-class-name: org.h2.Driver
+    hikari:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: create-drop
     properties:
       hibernate:
         format_sql: true
-
+    defer-datasource-initialization : true
 logging.level:
   org.hibernate.SQL: debug

--- a/portfolio-server/src/main/resources/application.yml
+++ b/portfolio-server/src/main/resources/application.yml
@@ -9,4 +9,4 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create

--- a/portfolio-server/src/main/resources/data.sql
+++ b/portfolio-server/src/main/resources/data.sql
@@ -1,0 +1,2 @@
+INSERT INTO Member (id,created_date, last_modified_date) VALUES (1,current_timestamp,current_timestamp);
+INSERT INTO Member (id,created_date, last_modified_date) VALUES (2,current_timestamp,current_timestamp);

--- a/portfolio-server/src/test/java/com/example/portfolioserver/domain/portfolio/dao/PortfolioRepositoryTest.java
+++ b/portfolio-server/src/test/java/com/example/portfolioserver/domain/portfolio/dao/PortfolioRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.example.portfolioserver.domain.portfolio.dao;
+
+import com.example.portfolioserver.domain.basicinfo.entity.BasicInfo;
+import com.example.portfolioserver.domain.member.entity.Member;
+import com.example.portfolioserver.domain.portfolio.entity.Portfolio;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+
+@SpringBootTest
+@Transactional
+@Rollback(value = false)
+class PortfolioRepositoryTest {
+
+    @PersistenceContext
+    EntityManager em;
+
+    @Autowired
+    PortfolioRepository portfolioRepository;
+
+    Member member;
+
+    @BeforeEach
+    void setup() {
+        member = new Member();
+        em.persist(member);
+        em.flush();
+        em.clear();
+    }
+
+//    @Test
+//    void portfolioInsertTest() {
+//        BasicInfo basicInfo = new BasicInfo("name", "Email@email", "200-12323");
+//        Portfolio portfolio = new Portfolio(basicInfo);
+//        portfolioRepository.save(portfolio);
+//
+//        Portfolio foundPortfolio = portfolioRepository.getById(portfolio.getId());
+//        Assertions.assertThat(foundPortfolio.getBasicInfo().getName()).isEqualTo(basicInfo.getName());
+//        Assertions.assertThat(foundPortfolio.getBasicInfo().getEmail()).isEqualTo(basicInfo.getEmail());
+//        Assertions.assertThat(foundPortfolio.getBasicInfo().getMobile()).isEqualTo(basicInfo.getMobile());
+//        Assertions.assertThat(foundPortfolio.getMember().getId()).isEqualTo(member.getId());
+//    }
+}


### PR DESCRIPTION
1. DB 구조
    1. Portfolio - BasicInfo : 일대일 단방향
    2. Portfolio - EducationalHistory : 일대다 양방향
    3. Portfolio - Career : 일대다 양방향
   -> 저번에 이야기 한 것 처럼 단방향으로도 한번 작업해보았습니다. 한번 확인 후 의견 있으시면 알려주시면 감사하겠습니다.

2. Portfolio 구조와 Register, Edit 할 때의 방법이 좋은 방법인지 일단 좀 더 고민해볼 필요가 있을 것으로 생각됨

3. Portfolio 조회할 때는 fetch join을 위해 querydsl 사용

4. JacksonConfig에서 LocalDate, LocalDateTime String 형식 지정

5. 최대한 setter는 엔티티 클래스에서는 사용하지 않으려고 노력함